### PR TITLE
compressed-tensors 0.15.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "compressed-tensors" %}
-{% set version = "0.10.2" %}
+{% set version = "0.15.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name | replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 6de13ac535d7ffdd8890fad3d229444c33076170acaa8fab6bab8ecfa96c1d8f
+  sha256: a8e93054e8a5ec49c980b09ed36c4c1249b4a8ee167920a8e461c4da26e78d99
 
 build:
   skip: true # [py<310]
@@ -26,8 +26,9 @@ requirements:
   run:
     - python
     - pytorch >=1.7.0
-    - transformers
+    - transformers >=4.45.0
     - pydantic >=2.0
+    - loguru
 
 test:
   imports:
@@ -58,5 +59,4 @@ extra:
   recipe-maintainers:
     - ianaobi
     - bkreider
-  recipe-maintainers:
     - maresb

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,10 @@ requirements:
     - transformers >=4.45.0
     - pydantic >=2.0
     - loguru
+    # Eager runtime import in compressed_tensors/offload/load.py — not listed
+    # in upstream `requires_dist` but required at import time of the top-level
+    # `compressed_tensors` package.
+    - psutil
 
 test:
   imports:
@@ -48,6 +52,7 @@ about:
     unified format for handling different model optimizations like GPTQ, AWQ,
     SmoothQuant, INT8, FP8, SparseGPT, and more.
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
   doc_url: https://github.com/vllm-project/compressed-tensors
   dev_url: https://github.com/vllm-project/compressed-tensors


### PR DESCRIPTION
compressed-tensors 0.15.0.1

**Destination channel:** defaults

### Links

- [PKG-14797](https://anaconda.atlassian.net/browse/PKG-14797)
- Upstream repository: https://github.com/vllm-project/compressed-tensors
- Upstream tag: https://github.com/vllm-project/compressed-tensors/releases/tag/0.15.0.1
- Diff: https://github.com/vllm-project/compressed-tensors/compare/0.10.2...0.15.0.1
- Parent ticket: [PKG-13217](https://anaconda.atlassian.net/browse/PKG-13217) (vllm latest)

### Explanation of changes:

- Version bump 0.10.2 → 0.15.0.1; sha256 refreshed from the PyPI sdist.
- Added `loguru` to run deps — new upstream runtime requirement in the 0.15.x series (per `requires_dist`). `loguru 0.7.3` is on pkgs/main.
- Bumped `transformers` lower bound: unversioned → `>=4.45.0`, matching the upstream `requires_dist` minimum.
- Cleanup: merged the two duplicate `extra.recipe-maintainers` keys into a single list. YAML keeps only the last key, so `ianaobi`/`bkreider` were being silently dropped in favor of `maresb` alone; all three are now retained.
- Dev/accelerate extras intentionally not included (test/dev deps).
- Build number 0 (new version).

[PKG-14797]: https://anaconda.atlassian.net/browse/PKG-14797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13217]: https://anaconda.atlassian.net/browse/PKG-13217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ