### PR TITLE
compressed-tensors 0.15.0.1 follow-up: remove pytorch from host

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: true # [py<310]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 0
 
 requirements:
   host:
@@ -22,7 +22,6 @@ requirements:
     - setuptools-scm >=8.2.0,<9.0.0
     - pip
     - wheel
-    - pytorch {{ pytorch }}
   run:
     - python
     - pytorch >=1.7.0
@@ -54,7 +53,6 @@ about:
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  license_family: Apache
   doc_url: https://github.com/vllm-project/compressed-tensors
   dev_url: https://github.com/vllm-project/compressed-tensors
 


### PR DESCRIPTION
compressed-tensors 0.15.0.1 follow-up

**Destination channel:** defaults

### Links

- [PKG-14797](https://anaconda.atlassian.net/browse/PKG-14797)
- Previous PR: [#4](https://github.com/AnacondaRecipes/compressed-tensors-feedstock/pull/4) (0.15.0.1, merged but release_task never fired)
- Failed release graph: [2262cb05](https://package-build.anaconda.com//v1/graph/2262cb05-0e46-4e3c-b923-94f16fd212dd)
- Parent epic: [PKG-13074](https://anaconda.atlassian.net/browse/PKG-13074) (2026Q2 AI & Growth Packages) via [PKG-13217](https://anaconda.atlassian.net/browse/PKG-13217) (vllm latest)

### Explanation of changes:

- **Why the previous release didn't ship:** the release graph 2262cb05 had 66 builds complete but 8 py3.14 builds failed (2 variants × 4 platforms). `release_task` is gated on all builds completing, so 0.15.0.1 never made it to pkgs/main. The py3.14 failures were caused by PBP's variant matrix expanding compressed-tensors against pytorch's CUDA sub-variants: PBP's frozen CBC selected `pytorch 2.7` (which has no py3.14 build on pkgs/main), and the CUDA variants additionally fail on non-GPU CI workers (missing `__cuda` virtual package).

- **Removed `pytorch {{ pytorch }}` from `host:`.** compressed-tensors is a pure-Python wrapper — no `.cu` files, no native extensions, and `pip install . --no-deps --no-build-isolation` does not need pytorch at build time. Removing it collapses the variant matrix to one build per Python version (4× fewer builds per platform) and decouples compressed-tensors entirely from pytorch's CUDA build expansion.

  Run dep `pytorch >=1.7.0` is unchanged — downstream consumers (vllm, transformers, etc.) still pin their own pytorch flavor, and the solver resolves a matching variant at install time. This matches the convention used by [conda-forge's compressed-tensors recipe](https://github.com/conda-forge/compressed-tensors-feedstock/blob/main/recipe/meta.yaml) and by AR's `transformers`, `peft`, and `accelerate` feedstocks.

- **Reset build number 1 → 0.** No 0.15.0.1 artifacts shipped to pkgs/main from the previous attempt (release_task was unscheduled), so a fresh build #0 is appropriate.

- **Dedup `license_family: Apache`** — the merged base had the field after `license_file:`, and PR #4's edit added another instance right after `license:`. YAML keeps only the last key, but the duplication was visually noisy.

### Forward-compatibility for vllm latest

The vllm latest update ([PKG-13217](https://anaconda.atlassian.net/browse/PKG-13217)) will pin `compressed-tensors` to 0.15.x. Since this PR keeps `pytorch >=1.7.0` in run (no upper bound) and drops the host pin entirely, the solver will compose compressed-tensors with whichever pytorch flavor vllm's CPU and CUDA builds resolve to. Verified: conda-forge's vllm chain uses the same pure-Python compressed-tensors pattern.

[PKG-14797]: https://anaconda.atlassian.net/browse/PKG-14797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13074]: https://anaconda.atlassian.net/browse/PKG-13074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13217]: https://anaconda.atlassian.net/browse/PKG-13217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13217]: https://anaconda.atlassian.net/browse/PKG-13217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ